### PR TITLE
build: compat with kernel >= 5.15.36

### DIFF
--- a/natflow_common.h
+++ b/natflow_common.h
@@ -324,7 +324,7 @@ static inline unsigned long nf_ct_expires(const struct nf_conn *ct)
 }
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 36)
 #define REFCOUNT_inc_not_zero atomic_inc_not_zero
 #define REFCOUNT_read atomic_read
 #else


### PR DESCRIPTION
Signed-off-by: PussAzuki <z1250747241@gmail.com>

Kernel 5.16 branch already EOL, simply make kernel >= 5.15.36 work