### PR TITLE
ipset: add compatibility wrapper and Makefile kernel-dir checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,25 @@ endif
 KERNELDIR ?= /lib/modules/$(KERNELRELEASE)/build
 KMAKE := $(MAKE) -C $(KERNELDIR) M=$(PWD)
 
+check-kerneldir:
+	@if [ ! -d "$(KERNELDIR)" ]; then \
+		echo "ERROR: kernel build dir not found: $(KERNELDIR)"; \
+		echo "Hint: install headers for $(KERNELRELEASE), or pass KERNELDIR=/path/to/linux/build"; \
+		exit 1; \
+	fi
+
 all: modules
 
-modules:
+modules: check-kerneldir
 	$(KMAKE) modules
 
-modules_install:
+modules_install: check-kerneldir
 	$(KMAKE) modules_install
 
 install: modules_install
 	depmod
 
 modules_clean:
-	$(KMAKE) clean
+	@if [ -d "$(KERNELDIR)" ]; then $(KMAKE) clean; else echo "Skip clean: $(KERNELDIR) not found"; fi
 
 clean: modules_clean

--- a/natflow_common.c
+++ b/natflow_common.c
@@ -10,6 +10,7 @@
 #include <linux/highmem.h>
 #include <linux/udp.h>
 #include <linux/netfilter.h>
+#include <linux/netlink.h>
 #include <net/netfilter/nf_conntrack.h>
 #include <net/netfilter/nf_conntrack_core.h>
 #include <net/netfilter/nf_conntrack_zones.h>
@@ -238,6 +239,36 @@ struct natflow_t *natflow_session_get(struct nf_conn *ct)
 	return nf;
 }
 
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 22)
+static ip_set_id_t natflow_ip_set_get_byname(struct net *net, const char *ip_set_name, struct ip_set **set)
+{
+	struct {
+		struct nlattr nla;
+		char name[IPSET_MAXNAMELEN];
+	} name_attr;
+	size_t name_len;
+
+	memset(&name_attr, 0, sizeof(name_attr));
+	name_len = strnlen(ip_set_name, IPSET_MAXNAMELEN - 1);
+	memcpy(name_attr.name, ip_set_name, name_len);
+	name_attr.nla.nla_type = 0;
+	name_attr.nla.nla_len = nla_attr_size(name_len + 1);
+
+	return ip_set_get_byname(net, &name_attr.nla, set);
+}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+static inline ip_set_id_t natflow_ip_set_get_byname(struct net *net, const char *ip_set_name, struct ip_set **set)
+{
+	return ip_set_get_byname(net, ip_set_name, set);
+}
+#else
+static inline ip_set_id_t natflow_ip_set_get_byname(const char *ip_set_name, struct ip_set **set)
+{
+	return ip_set_get_byname(ip_set_name, set);
+}
+#endif
+
 const char *const hooknames[] = {
 	[NF_INET_PRE_ROUTING] = "PRE",
 	[NF_INET_LOCAL_IN] = "IN",
@@ -286,9 +317,9 @@ int ip_set_test_src_ip(const struct net_device *in, const struct net_device *out
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		return -EINVAL;
@@ -345,9 +376,9 @@ int ip_set_test_dst_ip(const struct net_device *in, const struct net_device *out
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		NATFLOW_DEBUG("ip_set '%s' not found\n", ip_set_name);
@@ -405,9 +436,9 @@ int ip_set_test_dst_netport(const struct net_device *in, const struct net_device
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		NATFLOW_DEBUG("ip_set '%s' not found\n", ip_set_name);
@@ -465,9 +496,9 @@ int ip_set_add_src_ip(const struct net_device *in, const struct net_device *out,
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		NATFLOW_DEBUG("ip_set '%s' not found\n", ip_set_name);
@@ -525,9 +556,9 @@ int ip_set_add_dst_ip(const struct net_device *in, const struct net_device *out,
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		NATFLOW_DEBUG("ip_set '%s' not found\n", ip_set_name);
@@ -585,9 +616,9 @@ int ip_set_del_src_ip(const struct net_device *in, const struct net_device *out,
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		NATFLOW_DEBUG("ip_set '%s' not found\n", ip_set_name);
@@ -645,9 +676,9 @@ int ip_set_del_dst_ip(const struct net_device *in, const struct net_device *out,
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		NATFLOW_DEBUG("ip_set '%s' not found\n", ip_set_name);
@@ -705,9 +736,9 @@ int ip_set_test_src_mac(const struct net_device *in, const struct net_device *ou
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	id = ip_set_get_byname(net, ip_set_name, &set);
+	id = natflow_ip_set_get_byname(net, ip_set_name, &set);
 #else
-	id = ip_set_get_byname(ip_set_name, &set);
+	id = natflow_ip_set_get_byname(ip_set_name, &set);
 #endif
 	if (id == IPSET_INVALID_ID) {
 		return -EINVAL;


### PR DESCRIPTION
### Motivation

- Ensure `ip_set_get_byname` is called correctly across kernel versions where its prototype changed and make builds more robust when kernel headers are absent.

### Description

- Add `#include <linux/netlink.h>` to support building with newer kernel APIs.
- Introduce `natflow_ip_set_get_byname` wrapper with implementations for `>= 6.18.22`, `>= 3.13.0`, and older kernels to adapt to differing `ip_set_get_byname` signatures.
- Replace direct calls to `ip_set_get_byname` with `natflow_ip_set_get_byname` in all `ip_set_*` helper functions to centralize compatibility handling.
- Update `Makefile` to add a `check-kerneldir` target, make `modules` and `modules_install` depend on it, and make `modules_clean` skip cleaning when `KERNELDIR` is not present.

### Testing

- Built the kernel module using `make modules` and `make modules_install` on a host with matching kernel headers, and the build completed successfully.
- Executed `make clean`/`make modules_clean` on a host without `KERNELDIR` to verify the clean step is skipped and prints a helpful message, and the commands behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2daa6b900832fa0e43efd88cc5e7d)